### PR TITLE
fix(sim): ボールを宇宙へ発射しない（退避位置からのキック発射を修正）🚀

### DIFF
--- a/src/qml/sim/Control.qml
+++ b/src/qml/sim/Control.qml
@@ -14,11 +14,15 @@ QtObject {
         kickTimer.running = true;
         color.kickspeeds[i].x *= observer.kickerFriction;
         color.kickspeeds[i].y *= observer.kickerFriction;
-        ball.setLinearVelocity(Qt.vector3d(
+        // Defer the launch: store the velocity and let updateGameObjects() apply it only
+        // after the ball.reset() above has actually moved the ball back to the mouth
+        // (next physics step). Applying it now would launch the ball from the off-field
+        // park position (x~100000) and send it flying into the void.
+        pendingKickVelocity = Qt.vector3d(
             color.kickspeeds[i].x * Math.cos(radian),
             color.kickspeeds[i].y,
             -color.kickspeeds[i].x * Math.sin(radian)
-        ));
+        );
     }
 
     function dribble(frame, isYellow, i, botRadianBall, botDistanceBall, color) {

--- a/src/qml/sim/GameObjects.qml
+++ b/src/qml/sim/GameObjects.qml
@@ -27,6 +27,7 @@ Node {
     property var selectedRobotColor: "blue"
     property real botCursorID: 0
     property var kickFlag: false
+    property var pendingKickVelocity: null
     property var preBallPosition: Qt.vector4d(0, 0, 0, 0)
     property var ballAngularVelocity: Qt.vector4d(0, 0, 0, 0)
     property var preBallAngularPosition: Qt.vector4d(0, 0, 0, 0)
@@ -375,6 +376,17 @@ Node {
                                     + teleopVelocity.y * teleopVelocity.y
                                     + teleopVelocity.z * teleopVelocity.z);
         let teleopActive = teleopSpeed > 1.0;
+        // Apply a deferred kick only once the ball has actually returned to the mouth.
+        // kick() teleports the parked ball (x~100000) back to the dribbler via the
+        // deferred ball.reset(), then stores the launch velocity here. Waiting until the
+        // ball is back on-field prevents it from being launched from the off-field park
+        // position and flying off into the void on the kick frame.
+        if (pendingKickVelocity !== null
+                && Math.abs(ball.position.x) < 50000
+                && Math.abs(ball.position.z) < 50000) {
+            ball.setLinearVelocity(pendingKickVelocity);
+            pendingKickVelocity = null;
+        }
         if (skipRollingFrictionFrames > 0)
             skipRollingFrictionFrames--;
         // Decelerate the rolling ball so a kick doesn't roll forever off the field
@@ -442,6 +454,7 @@ Node {
         if (target == "ball") {
             teleopVelocity = Qt.vector4d(0, 0, 0, 0);
             ballVelocity = Qt.vector4d(0, 0, 0, 0);
+            pendingKickVelocity = null;
             ball.reset(result.scenePosition, Qt.vector3d(0, 0, 0));
             ballPosition = Qt.vector4d(ball.position.x, ball.position.y, ball.position.z, 0);
             preBallPosition = ballPosition;


### PR DESCRIPTION
> #36（🦖 ロボットがボールを捕食する問題）のフォローアップ。#36 はマージ済み 🎉 ですが、その**最後の本命修正がマージに間に合わなかった**ので単独で出します。

## 🚀 症状：キックした瞬間、ボールが宇宙の彼方へ

#36 でセンチネル漏れ（捕食）と無限ロールは直りましたが、**「キックした瞬間にボールが彼方へ吹き飛んで消える」**症状が残っていました。

## 🔍 真相
ドリブル中、物理ボールは衝突回避のため場外 `(100000,0,100000)` に退避されます。`Control.qml kick()` は、退避ボールを口元へ戻す `ball.reset()` の**直後**に `ball.setLinearVelocity()` を呼んでいました:

```qml
if (ball.position.x > 50000) { ball.reset(口元) }  // ← 次の物理ステップまで遅延
ball.setLinearVelocity(kickVel)                    // ← reset適用前に速度が乗る
```

Qt Quick 3D Physics では `reset()` の適用は**次の物理ステップまで遅延**します（かつ退避中ボールはスリープしがち）。reset が効く前にキック速度が乗ると、ボールは**場外 100000 から発射**されて宇宙の彼方へ。最初の報告値 `pos=(100013.7, -100000.0)`（x がわずかに 100000 超）が動かぬ証拠でした。

## 🔧 治療：発射を1ステップ遅延
- **`Control.qml kick()`**: 速度を即適用せず `pendingKickVelocity` に保存。
- **`GameObjects.qml updateGameObjects()`**: ボールが実際に場内（`|x|,|z| < 50000`）へ戻ったのを確認してから `setLinearVelocity` を適用。reset が確実に効いた後、口元から発射される。
- **`GameObjects.qml resetPosition("ball")`**: 手動配置時に保留中のキック速度をクリア。

## ✅ 動作確認
- QML（ランタイム読込）のみの変更。sim 再起動で反映。
- ドリブル→キックで、**キックの瞬間にボールが消えない／彼方へ飛ばない**、ボールが口元方向へ飛ぶこと。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
